### PR TITLE
fix: build with mjs/cjs extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   ],
   "scripts": {
     "build": "run-p build:*",
-    "build:cjs": "esbuild ./src/index.ts --outdir=./dist/cjs --platform=node --bundle",
-    "build:esm": "esbuild ./src/index.ts --outdir=./dist/esm --platform=neutral --bundle --main-fields=main",
+    "build:cjs": "esbuild ./src/index.ts --outdir=./dist --out-extension:.js=.cjs --platform=node --bundle",
+    "build:esm": "esbuild ./src/index.ts --outdir=./dist --out-extension:.js=.mjs --platform=neutral --bundle --main-fields=main",
     "build:types": "tsc --declarationDir ./dist/types",
     "clean": "rm -rf ./dist",
     "prepublishOnly": "run-s ts:validate",
@@ -28,13 +28,13 @@
     "ts:type-check": "tsc --incremental --pretty --noEmit",
     "ts:validate": "run-s ts:type-check ts:check ts:depcheck test"
   },
-  "main": "./dist/cjs/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/types/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
     }
   },
   "dependencies": {


### PR DESCRIPTION
This was previously only tested with Nodejs 22, which worked fine,
however with lower versions, node is unable to determine what format the
bundle is just from the conditional exports.

To help these versions, we can generate esm/cjs modules with mjs/cjs, so
that node knows which format to load the files as.
