### PR TITLE
fix: force all method names to caps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@marcuslongmuir/openapi-typescript-helpers",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@marcuslongmuir/openapi-typescript-helpers",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "ajv": "8.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marcuslongmuir/openapi-typescript-helpers",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Types and utilities for creating framework-agnostic HTTP handlers and clients.",
   "license": "MIT",
   "keywords": [

--- a/src/client/makeOpenAPIRequest.ts
+++ b/src/client/makeOpenAPIRequest.ts
@@ -80,7 +80,7 @@ export async function makeOpenAPIRequest<
     headers.set("Content-Type", "application/json");
   }
   const request = new Request(url.toString(), {
-    method,
+    method: method.toUpperCase(),
     headers,
     body: req.body ? JSON.stringify(req.body) : undefined,
   });


### PR DESCRIPTION
PATCH requests failing as they are required to have the method as upper case